### PR TITLE
Fixing some crashes related to nil in queries

### DIFF
--- a/lib/tipi/rack.rb
+++ b/lib/tipi/rack.rb
@@ -61,7 +61,7 @@ module Tipi
         key, value = part.split('=', 2)
         if keys.nil? || keys.include?(key)
           value = URI.decode_www_form_component(value) if !value.nil?
-          res[key.to_sym] = value
+          res[key.to_sym] = value if !key.nil?
         end
       end
       res

--- a/lib/tipi/rack.rb
+++ b/lib/tipi/rack.rb
@@ -60,7 +60,7 @@ module Tipi
       str.split('&').each do |part|
         key, value = part.split('=', 2)
         if keys.nil? || keys.include?(key)
-          value = URI.decode_www_form_component(value)
+          value = URI.decode_www_form_component(value) if !value.nil?
           res[key.to_sym] = value
         end
       end

--- a/test/tipi/test_rack.rb
+++ b/test/tipi/test_rack.rb
@@ -128,6 +128,10 @@ module Tipi
         res = mock_request.get('/params?a=%2F')
         assert_equal 200, res.status
         assert_equal '{"a":"/"}', res.body
+
+        res = mock_request.get('/params?a&&')
+        assert_equal 200, res.status
+        assert_equal '{"a":null}', res.body
       end
 
       it "handles post body" do

--- a/test/tipi/test_rack.rb
+++ b/test/tipi/test_rack.rb
@@ -17,6 +17,11 @@ module Tipi
           options
         end
 
+        input ".Hash"
+        def no_keys(options = {})
+          options
+        end
+
         class WeirdResponse
           def to_response
             [409,{},['Foo']]
@@ -74,6 +79,7 @@ module Tipi
           resource Root do
             get to: 'index'
             get '/params', to: 'params'
+            post '/no_keys', to: 'no_keys'
             get '/custom', to: 'custom'
             get '/initial_state', to: 'initial_state'
             path '/users', to: 'users', returns: Users
@@ -133,7 +139,7 @@ module Tipi
         assert_equal 200, res.status
         assert_equal '{"a":null}', res.body
       end
-
+        
       it "handles post body" do
         res = mock_request.post('/users/123', input: '{"name":"Bob"}', "CONTENT_TYPE" => 'application/json')
         assert_equal 200, res.status
@@ -150,6 +156,12 @@ module Tipi
         res = mock_request.post('/users/123', params: { name: "Bob" })
         assert_equal 200, res.status
         assert_equal '{"name":"Bob"}', res.body
+      end
+
+      it "handles weird post body" do
+        res = mock_request.post('/no_keys', input: 'name=bob&&a=&a&', "CONTENT_TYPE" => 'application/x-www-form-urlencoded')
+        assert_equal 200, res.status
+        assert_equal '{"name":"bob","a":null}', res.body
       end
 
       it "can generate custom responses" do

--- a/test/tipi/test_rack.rb
+++ b/test/tipi/test_rack.rb
@@ -173,7 +173,6 @@ module Tipi
       it "can set initial state" do
         app.setup_root = proc do |root, env|
           root.state[:foo] = 'initial state';
-          p env
         end
 
         res = mock_request.get('/initial_state')

--- a/test/tipi/test_rack.rb
+++ b/test/tipi/test_rack.rb
@@ -172,12 +172,13 @@ module Tipi
 
       it "can set initial state" do
         app.setup_root = proc do |root, env|
-          root.state[:foo] = env['rack.version']
+          root.state[:foo] = 'initial state';
+          p env
         end
 
         res = mock_request.get('/initial_state')
         assert_equal 200, res.status
-        assert_equal "[1,2]", res.body
+        assert_equal '"initial state"', res.body
       end
     end
   end


### PR DESCRIPTION
Both the key and value parts can contain nil in parse_query. Posting this stripe event through tipi triggered both cases:

{"created"=>1326853478, "livemode"=>false, "id"=>"evt_00000000000000", "type"=>"customer.subscription.deleted", "object"=>"event", "request"=>nil, "data"=>{"object"=>{"id"=>"sub_00000000000000", "plan"=>{"interval"=>"month", "name"=>"-JYI_nRwd_ltcGRLnVys", "created"=>1412299176, "amount"=>2000, "currency"=>"usd", "id"=>"1", "object"=>"plan", "livemode"=>false, "interval_count"=>1, "trial_period_days"=>nil, "metadata"=>{}, "statement_description"=>nil}, "object"=>"subscription", "start"=>1414767887, "status"=>"canceled", "customer"=>"cus_5vKmzpoFGczIjF", "cancel_at_period_end"=>false, "current_period_start"=>1414767887, "current_period_end"=>1417359887, "ended_at"=>1414739965, "trial_start"=>nil, "trial_end"=>nil, "canceled_at"=>nil, "quantity"=>1, "application_fee_percent"=>nil, "discount"=>nil, "metadata"=>{}}}}
